### PR TITLE
Fix date-time format definition

### DIFF
--- a/lib/ruby-swagger/grape/type.rb
+++ b/lib/ruby-swagger/grape/type.rb
@@ -55,8 +55,8 @@ module Swagger::Grape
         when 'date'
           swagger_type['type'] = 'date'
         when 'datetime'
+          swagger_type['type'] = 'string'
           swagger_type['format'] = 'date-time'
-          swagger_type['format'] = 'string'
         else
           swagger_type['type'] = "object"
 


### PR DESCRIPTION
Fix typo inside `Grape::Type#type_convert` when dealing with `data-time` swagger format. Before that all `date-time`s were being displayed as `string`.

<img width="419" alt="screen shot 2015-08-06 at 3 33 11 pm" src="https://cloud.githubusercontent.com/assets/379894/9120041/78c2fe52-3c50-11e5-8910-17ae650e32e8.png">
