### PR TITLE
translates grape values to swagger enum

### DIFF
--- a/lib/ruby-swagger/grape/param.rb
+++ b/lib/ruby-swagger/grape/param.rb
@@ -11,6 +11,7 @@ module Swagger::Grape
       swagger_param = {}
       swagger_param['description'] = @param[:desc]  if @param[:desc].present?
       swagger_param['default'] = @param[:default]   if @param[:default].present?
+      swagger_param['enum'] = @param[:values]   if @param[:values].present?
 
       swagger_param.merge! Swagger::Grape::Type.new(@param[:type]).to_swagger
 


### PR DESCRIPTION
Just added the grape-to-swagger translation for parameter enums. We need it in our current project and since it's straight forward I thought it would be a good thing to contribute it.