### PR TITLE
Fix date format definition

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-swagger (0.0.2)
+    ruby-swagger (0.0.3)
       addressable
 
 GEM
@@ -13,7 +13,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
+    addressable (2.4.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)

--- a/lib/ruby-swagger/grape/type.rb
+++ b/lib/ruby-swagger/grape/type.rb
@@ -53,7 +53,8 @@ module Swagger::Grape
           swagger_type['type'] = 'string'
           STDERR.puts "Warning - I have no idea how to handle the type file. Right now I will consider this a string, but we should probably handle it..."
         when 'date'
-          swagger_type['type'] = 'date'
+          swagger_type['type'] = 'string'
+          swagger_type['format'] = 'date'
         when 'datetime'
           swagger_type['type'] = 'string'
           swagger_type['format'] = 'date-time'


### PR DESCRIPTION
Much like PR #22, there is a problem with date types creating improper v2.0 compliant JSON:

`date` now produces the following JSON:
```ruby
"type": "date"
```

As per v2.0 spec https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#data-types, `date` should produce:
```ruby
"type": "string",
"format": "date"
```

Gemfile lock file was also updated while running specs.  (No specs for proper 2.0 compliant output??)