### PR TITLE
support Grape::Entity Arrays of items other than String

### DIFF
--- a/lib/ruby-swagger/grape/type.rb
+++ b/lib/ruby-swagger/grape/type.rb
@@ -94,7 +94,7 @@ module Swagger::Grape
                 #it's either an object or an array of object
                 using = type_convert(definition[:using].to_s, true)
                 
-                if definition[:documentation][:type].present? && definition[:documentation][:type] == 'array'
+                if definition[:documentation][:type].present? && definition[:documentation][:type].downcase == 'array'
                   cursor['properties'][target]['items'] = using
                 else
                   cursor['properties'][target] = using

--- a/lib/ruby-swagger/grape/type.rb
+++ b/lib/ruby-swagger/grape/type.rb
@@ -94,7 +94,7 @@ module Swagger::Grape
                 #it's either an object or an array of object
                 using = type_convert(definition[:using].to_s, true)
                 
-                if definition['type'].present? && definition['type'] == 'array'
+                if definition[:documentation][:type].present? && definition[:documentation][:type] == 'array'
                   cursor['properties'][target]['items'] = using
                 else
                   cursor['properties'][target] = using


### PR DESCRIPTION
I was trying to expose an Entity field that is an Array of Integers like so:
```ruby
expose(:subcategories, using: Integer, documentation: { type: 'Array', desc: 'array of subcategory ids, if any' })
```
But the output definition YML just contained:
```ruby
  subcategories:
    type: integer
    description: array of subcategory ids, if any
```
Tracked it down to handling of the ```:using``` option.  Fixed up and now we have proper output:
```ruby
  subcategories:
    type: array
    items:
      type: integer
    description: array of subcategory ids, if any
```
I'd love to add to existing specs for Grape params but I don't see any.