### PR TITLE
Grape parameters marked 'optional' need to be explicitly required=false in Swagger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-swagger (0.0.2)
+    ruby-swagger (0.0.3)
       addressable
 
 GEM
@@ -13,7 +13,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
+    addressable (2.4.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)

--- a/lib/ruby-swagger/grape/param.rb
+++ b/lib/ruby-swagger/grape/param.rb
@@ -11,6 +11,7 @@ module Swagger::Grape
       swagger_param = {}
       swagger_param['description'] = @param[:desc]  if @param[:desc].present?
       swagger_param['default'] = @param[:default]   if @param[:default].present?
+      swagger_param['required'] = @param[:required]   if @param.has_key?(:required)
 
       swagger_param.merge! Swagger::Grape::Type.new(@param[:type]).to_swagger
 

--- a/spec/swagger/integration_spec.rb
+++ b/spec/swagger/integration_spec.rb
@@ -155,7 +155,7 @@ describe 'Ruby::Swagger' do
     end
 
     describe 'params' do
-      it 'should get parameters for applications/get.yml' do
+      it 'should get parameters for applications/{id}/check_access/get.yml' do
         doc = open_yaml('./doc/swagger/paths/applications/{id}/check_access/get.yml')
 
         expect(doc['parameters'].count).to eq 2
@@ -187,16 +187,19 @@ describe 'Ruby::Swagger' do
         expect(doc['parameters'][1]['in']).to eq 'query'
         expect(doc['parameters'][1]['description']).to eq 'Number of profiles returned. Default is 30 elements, max is 100 elements per page.'
         expect(doc['parameters'][1]['type']).to eq 'integer'
+        expect(doc['parameters'][1]['required']).to eq false
 
         expect(doc['parameters'][2]['name']).to eq 'offset'
         expect(doc['parameters'][2]['in']).to eq 'query'
         expect(doc['parameters'][2]['description']).to eq 'Offset for pagination result. Use it combined with the limit field. Default is 0.'
         expect(doc['parameters'][2]['type']).to eq 'integer'
+        expect(doc['parameters'][2]['required']).to eq false
 
         expect(doc['parameters'][3]['name']).to eq 'q[service]'
         expect(doc['parameters'][3]['in']).to eq 'query'
         expect(doc['parameters'][3]['description']).to eq 'Filter by application exposing a given service'
         expect(doc['parameters'][3]['type']).to eq 'string'
+        expect(doc['parameters'][3]['required']).to eq false
       end
 
       it 'should get parameters for applications/post.yml' do


### PR DESCRIPTION
Currently, ```optional``` query parameters omit the ```required: ``` property completely in output Swagger.

Without explicitly marking optional params as ```required: false``` in the output swagger, some clients treat the parameter in question as required (for whatever reasons).

This ensures we explicitly add the `required` property to the output.  
Note that I'm using ```@param.has_key?(:required)``` in Swagger::Grape::Param since a test for ```@param[:required].present?``` would fail for a boolean value of ```false```.

I've added additional tests in the integration spec where appropriate as well as fixed up the naming of a spec.

