### PR TITLE
Revert "support Grape::Entity Arrays of items other than String"

### DIFF
--- a/lib/ruby-swagger/grape/type.rb
+++ b/lib/ruby-swagger/grape/type.rb
@@ -95,7 +95,7 @@ module Swagger::Grape
                 #it's either an object or an array of object
                 using = type_convert(definition[:using].to_s, true)
                 
-                if definition[:documentation][:type].present? && definition[:documentation][:type].downcase == 'array'
+                if definition['type'].present? && definition['type'] == 'array'
                   cursor['properties'][target]['items'] = using
                 else
                   cursor['properties'][target] = using


### PR DESCRIPTION
Reverts Gild/ruby-swagger#36

@alexagranov I had to revert your PR since several spec are now failing

```
1) Ruby::Swagger rake swagger:grape:generate_doc should generate a base_doc.yml
     Failure/Error: rake_task.invoke('ApplicationsAPI')
     NoMethodError:
       undefined method `downcase' for Array:Class
     # ./lib/ruby-swagger/grape/type.rb:98:in `block in type_convert'
     # ./lib/ruby-swagger/grape/type.rb:74:in `each'
     # ./lib/ruby-swagger/grape/type.rb:74:in `type_convert'
     # ./lib/ruby-swagger/grape/type.rb:11:in `to_swagger'
     # ./lib/ruby-swagger/grape/grape_template.rb:23:in `block in generate'
     # ./lib/ruby-swagger/grape/grape_template.rb:20:in `each'
     # ./lib/ruby-swagger/grape/grape_template.rb:20:in `generate'
     # ./lib/tasks/swagger.rake:24:in `block (3 levels) in <top (required)>'
     # ./spec/swagger/integration_spec.rb:33:in `block (3 levels) in <top (required)>'
```

Do you have a chance to take a look at this?

Thanks!!!