### PR TITLE
name body params according to api_name, if present

### DIFF
--- a/lib/ruby-swagger/grape/method.rb
+++ b/lib/ruby-swagger/grape/method.rb
@@ -210,7 +210,8 @@ module Swagger::Grape
       #include all the parameters that are in the content-body
       return unless @route.route_params && @route.route_params.length > 0
 
-      root_param = Swagger::Data::Parameter.parse({'name' => 'body',
+      body_name = @operation.operationId ? "#{@operation.operationId}_body" : 'body'
+      root_param = Swagger::Data::Parameter.parse({'name' => body_name,
                                                    'in' => 'body',
                                                    'description' => 'the content of the request',
                                                    'schema' => {'type' => 'object', 'properties' => {}}})

--- a/spec/swagger/grape/application_api.rb
+++ b/spec/swagger/grape/application_api.rb
@@ -121,6 +121,7 @@ class ApplicationsAPI < Grape::API
       headers authentication_headers
       scopes 'application:read'
       tags %w(applications create swag)
+      api_name 'post_applications'
     end
     params do
       requires :id, type: String, desc: "Unique identifier or code name of the application"

--- a/spec/swagger/integration_spec.rb
+++ b/spec/swagger/integration_spec.rb
@@ -16,11 +16,11 @@ describe 'Ruby::Swagger' do
   end
 
   before do
-#    FileUtils.rm_rf("./doc/swagger")
+    FileUtils.rm_rf("./doc/swagger")
   end
 
   after do
-#    FileUtils.rm_rf("./doc/swagger")
+    FileUtils.rm_rf("./doc/swagger")
   end
 
   describe 'rake swagger:grape:generate_doc' do

--- a/spec/swagger/integration_spec.rb
+++ b/spec/swagger/integration_spec.rb
@@ -16,11 +16,11 @@ describe 'Ruby::Swagger' do
   end
 
   before do
-    FileUtils.rm_rf("./doc/swagger")
+#    FileUtils.rm_rf("./doc/swagger")
   end
 
   after do
-    FileUtils.rm_rf("./doc/swagger")
+#    FileUtils.rm_rf("./doc/swagger")
   end
 
   describe 'rake swagger:grape:generate_doc' do
@@ -152,6 +152,14 @@ describe 'Ruby::Swagger' do
       it 'should include an operationId in applications/{id}/check_access/get.yml' do
         expect(open_yaml('./doc/swagger/paths/applications/get.yml')['operationId']).to eq "get_applications"
       end
+
+      it 'should include an operationId in applications/{id}/check_access/post.yml' do
+        expect(open_yaml('./doc/swagger/paths/applications/{id}/post.yml')['operationId']).to eq "post_applications"
+      end
+
+      it 'should include an operationId in applications/{id}/check_access/put.yml' do
+        expect(open_yaml('./doc/swagger/paths/applications/{id}/put.yml')['operationId']).to eq "put_applications"
+      end
     end
 
     describe 'params' do
@@ -218,7 +226,7 @@ describe 'Ruby::Swagger' do
         expect(doc['parameters'][1]['type']).to eq 'string'
         expect(doc['parameters'][1]['required']).to be_truthy
 
-        expect(doc['parameters'][2]['name']).to eq 'body'
+        expect(doc['parameters'][2]['name']).to eq 'post_applications_body'
         expect(doc['parameters'][2]['in']).to eq 'body'
         expect(doc['parameters'][2]['description']).to eq 'the content of the request'
         expect(doc['parameters'][2]['schema']).not_to be_nil


### PR DESCRIPTION
Currently, all bodies for PUT/POST operations are given a name of ```'body'``` in the output schema.  This causes confusion when generating client code so it is necessary to modify Swagger spec to name each request body uniquely.

This PR uses ```api_name``` if present to name the body ```"#{api_name}_body"```.  Thereby avoiding the need to manually give each body a unique name.

I've modified specs where appropriate but ideally we could have a more modular ApplicationAPI that would allow specifically testing for how the request body was named.