### PR TITLE
enable parameter enum values

### DIFF
--- a/lib/ruby-swagger/grape/param.rb
+++ b/lib/ruby-swagger/grape/param.rb
@@ -11,6 +11,7 @@ module Swagger::Grape
       swagger_param['description'] = @param[:desc]  if @param[:desc].present?
       swagger_param['default'] = @param[:default]   if @param[:default].present?
       swagger_param['required'] = @param[:required] if @param.key?(:required)
+      swagger_param['enum'] = @param[:values] if @param[:values].present?
 
       swagger_param.merge! Swagger::Grape::Type.new(@param[:type]).to_swagger
 


### PR DESCRIPTION
Simple addition to param.rb to translate grape enums to swagger. Closed the old pull request from my private fork and opened a new one from my companies repo instead.