### PR TITLE
Don't assign a double slash to the basepath

### DIFF
--- a/lib/ruby-swagger/data/document.rb
+++ b/lib/ruby-swagger/data/document.rb
@@ -51,7 +51,7 @@ module Swagger::Data
     def basePath=(new_path)
       new_path = new_path.nil? ? '/' : new_path
 
-      unless new_path =~ /^\/.+$/
+      unless new_path =~ /^\//
         new_path = "/#{new_path}" # new path must start with a /
       end
 


### PR DESCRIPTION
ruby-swagger assigns a double slash to the basepath If it is a single slash or null.

```
doc = Swagger::Data::Document.new
doc.basePath = "api"
doc.basePath #=> "/api"

doc = Swagger::Data::Document.new
doc.basePath = '/'
doc.basePath #=> "//"

doc = Swagger::Data::Document.new
doc.basePath = nil
doc.basePath #=> "//"
```
