### PR TITLE
Refactor type matching and introduce grape shorthand primitive arrays

### DIFF
--- a/lib/ruby-swagger/grape/type.rb
+++ b/lib/ruby-swagger/grape/type.rb
@@ -8,11 +8,10 @@ module Swagger::Grape
 
     def initialize(type)
       @type = type.to_s || 'String'
-      @swagger_type = {}
     end
 
     def to_swagger(with_definition = true)
-      translate(@type, with_definition)
+      translate(with_definition)
     end
 
     def sub_types
@@ -21,47 +20,94 @@ module Swagger::Grape
 
     private
 
-    def translate(type, with_definition)
-      case type.downcase
-      when 'string'
-        @swagger_type['type'] = 'string'
-      when 'integer'
-        @swagger_type['type'] = 'integer'
-      when 'array'
-        @swagger_type['type'] = 'array'
-        @swagger_type['items'] = { 'type' => 'string' }
-      when 'hash'
-        @swagger_type['type'] = 'object'
-        @swagger_type['properties'] = {}
-      when 'boolean'
-        @swagger_type['type'] = 'boolean'
-      when 'virtus::attribute::boolean'
-        @swagger_type['type'] = 'boolean'
-      when 'symbol'
-        @swagger_type['type'] = 'string'
-      when 'float'
-        @swagger_type['type'] = 'number'
-        @swagger_type['format'] = 'float'
-      when 'rack::multipart::uploadedfile'
-        @swagger_type['type'] = 'string'
-        STDERR.puts 'Warning - I have no idea how to handle the type file. Right now I will consider this a string, but we should probably handle it...'
-      when 'date'
-        @swagger_type['type'] = 'string'
-        @swagger_type['format'] = 'date'
-      when 'datetime'
-        @swagger_type['type'] = 'string'
-        @swagger_type['format'] = 'date-time'
-      else
+    def translate(with_definition)
+      swagger_type = {}
 
+      # basic type
+      if basic_type?
+        swagger_type = basic_type_schemes[@type.downcase]
+
+      # grape shorthand array eg. `Array[Integer]`
+      elsif short_hand_array?
+        swagger_type = shorthand_array_scheme
+
+      # representer or entity object
+      else
         if with_definition
-          # I can just reference the name of the object here
-          @swagger_type['type'] = 'object'
-          @swagger_type['$ref'] = "#/definitions/#{type}"
+          # I can just reference the name of the representer here
+          swagger_type = {
+            'type' => 'object',
+            '$ref' => "#/definitions/#{@type}"
+          }
+
+        # grape-entity object
         else
-          @swagger_type = Swagger::Grape::Entity.new(type).to_swagger
+          swagger_type = Swagger::Grape::Entity.new(@type).to_swagger
         end
       end
-      @swagger_type
+      swagger_type
+    end
+
+    def short_hand_array?
+      !(@type.downcase =~ /\[[a-zA-Z]+\]/).nil?
+    end
+
+    def basic_type?
+      basic_type_schemes.key? @type.downcase
+    end
+
+    def shorthand_array_scheme
+      match = @type.downcase.match(/\[(.*?)\]/)
+      @swagger_type = {
+        'type' => 'array',
+        'items' => {
+          'type' => match[1]
+        }
+      }
+    end
+
+    def basic_type_schemes
+      {
+        'string' => {
+          'type' => 'string'
+        },
+        'integer' => {
+          'type' => 'integer'
+        },
+        'array' => {
+          'type' => 'array',
+          'items' => { 'type' => 'string' }
+        },
+        'hash' => {
+          'type' => 'object',
+          'properties' => {}
+        },
+        'boolean' => {
+          'type' => 'boolean'
+        },
+        'virtus::attribute::boolean' => {
+          'type' => 'boolean'
+        },
+        'symbol' => {
+          'type' => 'string'
+        },
+        'float' => {
+          'type' => 'number',
+          'format' => 'float'
+        },
+        'rack::multipart::uploadedfile' => {
+          'type' => 'string' # 'Warning - I have no idea how to handle the type file. Right now I will consider this a string, but we should probably handle it...'
+        },
+        'date' => {
+          'type' => 'string',
+          'format' => 'date'
+        },
+        'datetime' => {
+          'type' => 'string',
+          'format' => 'date-time'
+        }
+
+      }.freeze
     end
   end
 end


### PR DESCRIPTION
Slightly refactored type matching in type.rb plus support for grape shorthand array parameter eg. 
```
params do
   optional :primes, type: Array[Integer], desc: 'Some Primes'
end
```

For now the class inside the brackets is not validated but that it has to be a string of characters. If we want to allow only certain classes, this could be easily implemented.

Fixes #30