### PR TITLE
Add support to Roar

### DIFF
--- a/lib/ruby-swagger/grape/representer.rb
+++ b/lib/ruby-swagger/grape/representer.rb
@@ -1,0 +1,76 @@
+module Swagger
+  module Grape
+    class Representer
+      def initialize(type)
+        @type = type
+
+        unless representer < Representable || coercion?
+          raise ArgumentError.new("Expecting a Representable - Can't translate this!")
+        end
+      end
+
+      def to_swagger
+        if representer.respond_to?(:representable_attrs)
+          @swagger_definition ||= { 'type' => 'object', 'properties' => properties }
+        else
+          Type.new(String).to_swagger(false)
+        end
+      end
+
+      def sub_types
+        return [] if coercion?
+
+        definitions.flat_map do |definition, _|
+          options = definition.instance_variable_get(:@options)
+
+          if options[:_inline]
+            self.class.new(options[:extend]).sub_types
+          else
+            options[:extend] || options[:type]
+          end
+        end.compact.reject { |type| type.is_a?(String) }.uniq
+      end
+
+      private
+
+      attr_reader :type
+
+      def properties
+        definitions.each_with_object({}) do |definition, properties|
+          options = definition.instance_variable_get(:@options)
+
+          if options[:_inline]
+            swagger_definition = self.class.new(options[:extend]).to_swagger
+            swagger_definition = collection_properties(swagger_definition) if options[:collection]
+          else
+            custom_definition = options[:extend] || options[:type]
+            swagger_definition = Type.new(custom_definition).to_swagger(!runtime_definition?(custom_definition))
+          end
+
+          properties[options[:as]] = swagger_definition
+          properties[options[:as]].merge!('description' => options[:desc]) if options[:desc]
+        end
+      end
+
+      def collection_properties(items_definition)
+        { 'type' => 'array', 'items' => items_definition }
+      end
+
+      def definitions
+        representer.representable_attrs[:definitions].except('links')
+      end
+
+      def coercion?
+        representer < Virtus::Attribute
+      end
+
+      def runtime_definition?(definition)
+        definition.to_s.include?('Class') || representer.to_s.include?('Class')
+      end
+
+      def representer
+        @representer ||= type.is_a?(String) ? Object.const_get(type) : type
+      end
+    end
+  end
+end

--- a/ruby-swagger.gemspec
+++ b/ruby-swagger.gemspec
@@ -12,9 +12,10 @@ This is the engine used in other gems to translate API definitions (grape, rails
 
   s.add_dependency 'addressable'
 
-  s.add_development_dependency 'rake', '>= 0.9.2'
-  s.add_development_dependency 'rspec'
   s.add_development_dependency 'grape'
   s.add_development_dependency 'grape-entity', '~> 0.5'
   s.add_development_dependency 'rack-test'
+  s.add_development_dependency 'rake', '>= 0.9.2'
+  s.add_development_dependency 'roar'
+  s.add_development_dependency 'rspec'
 end

--- a/spec/fixtures/grape/applications_api.rb
+++ b/spec/fixtures/grape/applications_api.rb
@@ -1,11 +1,12 @@
 require 'grape'
 require 'ruby-swagger'
 require 'ruby-swagger/grape/grape'
-require_relative '../grape/entities/application_entity'
-require_relative '../grape/entities/error_redirect_entity'
-require_relative '../grape/entities/error_not_found_entity'
-require_relative '../grape/entities/error_boom_entity'
-require_relative '../grape/entities/detailed_status_entity'
+
+require_relative './entities/errors'
+require_relative './entities/application_entity'
+require_relative './entities/status_detailed_entity'
+
+require_relative './representers/status_representer'
 
 class ApplicationsAPI < Grape::API
   version 'v1'
@@ -145,11 +146,27 @@ class ApplicationsAPI < Grape::API
       api_present true
     end
 
+    api_desc 'Roar translation' do
+      headers authentication_headers
+      scopes %w(application:read application:write application:execute)
+      tags %w(applications create swag more_swag)
+      response StatusRepresenter, isArray: true, headers: result_headers
+      api_name 'put_applications'
+    end
+    params do
+      requires :id, type: String, desc: 'Unique identifier or code name of the application'
+      requires :godzilla, type: Array, desc: 'Multiple options for this API'
+    end
+    put '/:id/roar' do
+      @application = { id: '123456', name: 'An app', description: 'Great App' }
+      api_present(@applications)
+    end
+
     api_desc 'Deactivate an application.' do
       headers authentication_headers
       scopes %w(application:read application:write application:execute)
       tags %w(applications create swag more_swag)
-      response StatusDetailed, isArray: true, headers: result_headers
+      response StatusDetailedEntity, isArray: true, headers: result_headers
       api_name 'put_applications'
     end
     params do

--- a/spec/fixtures/grape/entities/application_entity.rb
+++ b/spec/fixtures/grape/entities/application_entity.rb
@@ -1,5 +1,5 @@
-require 'grape'
 require 'grape-entity'
+
 require_relative './image_entity'
 
 class ApplicationEntity < Grape::Entity

--- a/spec/fixtures/grape/entities/errors.rb
+++ b/spec/fixtures/grape/entities/errors.rb
@@ -1,7 +1,9 @@
-require 'grape'
-require 'ruby-swagger'
+require 'grape-entity'
 
 class ErrorRedirectEntity < Grape::Entity
   expose(:errors, documentation: { type: 'Array', desc: 'errors produced by this method' })
   expose(:message, documentation: { type: 'String', desc: 'Why? Why? Why????' })
 end
+
+class ErrorNotFoundEntity < ErrorRedirectEntity; end
+class ErrorBoomEntity < ErrorRedirectEntity; end

--- a/spec/fixtures/grape/entities/image_entity.rb
+++ b/spec/fixtures/grape/entities/image_entity.rb
@@ -1,4 +1,3 @@
-require 'grape'
 require 'grape-entity'
 
 class ImageEntity < Grape::Entity

--- a/spec/fixtures/grape/entities/status_detailed_entity.rb
+++ b/spec/fixtures/grape/entities/status_detailed_entity.rb
@@ -1,0 +1,5 @@
+require_relative './status_entity'
+
+class StatusDetailedEntity < StatusEntity
+  expose :internal_id
+end

--- a/spec/fixtures/grape/entities/status_entity.rb
+++ b/spec/fixtures/grape/entities/status_entity.rb
@@ -1,8 +1,7 @@
-require 'grape'
 require 'grape-entity'
 require_relative './image_entity'
 
-class Status < Grape::Entity
+class StatusEntity < Grape::Entity
   format_with(:iso_timestamp, &:iso8601)
 
   expose :user_name
@@ -16,9 +15,9 @@ class Status < Grape::Entity
   expose :digest do |status, _options|
     Digest::MD5.hexdigest status.txt
   end
-  expose :replies, using: Status, as: :responses
+  expose :replies, using: StatusEntity, as: :responses
 
-  expose :last_reply, using: Status do |status, _options|
+  expose :last_reply, using: StatusEntity do |status, _options|
     status.replies.last
   end
 

--- a/spec/fixtures/grape/representers/image_representer.rb
+++ b/spec/fixtures/grape/representers/image_representer.rb
@@ -1,0 +1,9 @@
+require 'roar/json'
+
+class ImageRepresenter
+  include Roar::JSON
+
+  property :url, type: String, desc: 'The url of the image'
+  property :name, type: String, desc: 'The name of the image'
+  property :size, type: Integer, desc: 'Size of the picture'
+end

--- a/spec/fixtures/grape/representers/status_representer.rb
+++ b/spec/fixtures/grape/representers/status_representer.rb
@@ -1,0 +1,38 @@
+require 'roar/json'
+
+require_relative './image_representer'
+
+class StatusRepresenter
+  include Roar::JSON
+
+  property :user_name
+  property :text, desc: 'Status update text.'
+  property :ip
+  property :user_type
+  property :user_id
+
+  property :contact_info do
+    property :phone
+    property :address, type: ImageRepresenter
+  end
+
+  property :digest, getter: (lambda do |_options|
+    represented.replies.last
+  end)
+
+  property :replies, extend: StatusRepresenter, as: :responses
+  property :last_reply, extend: StatusRepresenter, getter: (lambda do |_options|
+    represented.replies.last
+  end)
+
+  collection :list, desc: 'List of elements' do
+    nested :option_a do
+      property :option_b, type: 'Array', desc: 'An option'
+    end
+
+    property :option_c, type: 'Integer', desc: 'Last option'
+  end
+
+  property :created_at
+  property :updated_at
+end

--- a/spec/swagger/grape/entities/detailed_status_entity.rb
+++ b/spec/swagger/grape/entities/detailed_status_entity.rb
@@ -1,7 +1,0 @@
-require 'grape'
-require 'grape-entity'
-require_relative './status_entity'
-
-class StatusDetailed < Status
-  expose :internal_id
-end

--- a/spec/swagger/grape/entities/error_boom_entity.rb
+++ b/spec/swagger/grape/entities/error_boom_entity.rb
@@ -1,4 +1,0 @@
-require_relative '../entities/error_redirect_entity'
-
-class ErrorBoomEntity < ErrorRedirectEntity
-end

--- a/spec/swagger/grape/entities/error_not_found_entity.rb
+++ b/spec/swagger/grape/entities/error_not_found_entity.rb
@@ -1,4 +1,0 @@
-require_relative '../entities/error_redirect_entity'
-
-class ErrorNotFoundEntity < ErrorRedirectEntity
-end

--- a/spec/swagger/grape/entity_spec.rb
+++ b/spec/swagger/grape/entity_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+require_relative '../../fixtures/grape/entities/status_entity'
+
+RSpec.describe Swagger::Grape::Entity do
+  describe '#to_swagger' do
+    it 'converts exposures definition into swagger definition' do
+      object_translator = described_class.new(StatusEntity.to_s)
+
+      expect(object_translator.to_swagger).to eq({
+        'type' => 'object',
+        'properties' => {
+          'user_name' => {
+            'type' => 'string'
+          },
+          'text' => {
+            'type' => 'string',
+            'description' => 'Status update text.'
+          },
+          'ip' => {
+            'type' => 'string'
+          },
+          'user_type' => {
+            'type' => 'string'
+          },
+          'user_id' => {
+            'type' => 'string'
+          },
+          'contact_info' => {
+            'type' => 'object',
+            'properties' => {
+              'phone' => {
+                'type' => 'string'
+              },
+              'address' => {
+                'type' => 'object',
+                '$ref' => '#/definitions/ImageEntity'
+              }
+            }
+          },
+          'digest' => {
+            'type' => 'string'
+          },
+          'responses' => {
+            'type' => 'object',
+            '$ref' => '#/definitions/StatusEntity'
+          },
+          'last_reply' => {
+            'type' => 'object',
+            '$ref' => '#/definitions/StatusEntity'
+          },
+          'list' => {
+            'type' => 'array',
+            'description' => 'List of elements',
+            'items' => {
+              'type' => 'object',
+              'properties' => {
+                'option_a' => {
+                  'type' => 'object',
+                  'properties' => {
+                    'option_b' => {
+                      'type' => 'array',
+                      'items' => {
+                        'type' => 'string'
+                      },
+                      'description' => 'An option'
+                    }
+                  }
+                },
+                'option_c' => {
+                  'type' => 'integer',
+                  'description' => 'Last option'
+                }
+              }
+            }
+          },
+          'created_at' => {
+            'type' => 'string'
+          },
+          'updated_at' => {
+            'type' => 'string'
+          }
+        }
+      })
+    end
+  end
+
+  describe '#sub_types' do
+    it 'returns nested objects of a given entity' do
+      object_translator = described_class.new(StatusEntity.to_s)
+
+      expect(object_translator.sub_types).to eq([ImageEntity, StatusEntity])
+    end
+  end
+end

--- a/spec/swagger/grape/grape-ext_spec.rb
+++ b/spec/swagger/grape/grape-ext_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
-require_relative '../grape/entities/application_entity'
-require_relative '../grape/application_api'
+require_relative '../../fixtures/grape/applications_api'
 
 describe Grape::DSL::Configuration do
   context 'with no overridden default values' do

--- a/spec/swagger/grape/grape_presenter_spec.rb
+++ b/spec/swagger/grape/grape_presenter_spec.rb
@@ -1,8 +1,7 @@
 require 'spec_helper'
 
 require 'rack/test'
-require_relative '../grape/entities/application_entity'
-require_relative '../grape/application_api'
+require_relative '../../fixtures/grape/applications_api'
 
 describe Grape::DSL::InsideRoute do
   include Rack::Test::Methods

--- a/spec/swagger/grape/roar_spec.rb
+++ b/spec/swagger/grape/roar_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+require_relative '../../fixtures/grape/representers/status_representer'
+
+RSpec.describe Swagger::Grape::Representer do
+  describe '#to_swagger' do
+    it 'converts exposures definition into swagger definition' do
+      object_translator = described_class.new(StatusRepresenter.to_s)
+
+      expect(object_translator.to_swagger).to eq({
+        'type' => 'object',
+        'properties' => {
+          'user_name' => {
+            'type' => 'string'
+          },
+          'text' => {
+            'type' => 'string',
+            'description' => 'Status update text.'
+          },
+          'ip' => {
+            'type' => 'string'
+          },
+          'user_type' => {
+            'type' => 'string'
+          },
+          'user_id' => {
+            'type' => 'string'
+          },
+          'contact_info' => {
+            'type' => 'object',
+            'properties' => {
+              'phone' => {
+                'type' => 'string'
+              },
+              'address' => {
+                'type' => 'object',
+                '$ref' => '#/definitions/ImageRepresenter'
+              }
+            }
+          },
+          'digest' => {
+            'type' => 'string'
+          },
+          'responses' => {
+            'type' => 'object',
+            '$ref' => '#/definitions/StatusRepresenter'
+          },
+          'last_reply' => {
+            'type' => 'object',
+            '$ref' => '#/definitions/StatusRepresenter'
+          },
+          'list' => {
+            'type' => 'array',
+            'description' => 'List of elements',
+            'items' => {
+              'type' => 'object',
+              'properties' => {
+                'option_a' => {
+                  'type' => 'object',
+                  'properties' => {
+                    'option_b' => {
+                      'type' => 'array',
+                      'items' => {
+                        'type' => 'string'
+                      },
+                      'description' => 'An option'
+                    }
+                  }
+                },
+                'option_c' => {
+                  'type' => 'integer',
+                  'description' => 'Last option'
+                }
+              }
+            }
+          },
+          'created_at' => {
+            'type' => 'string'
+          },
+          'updated_at' => {
+            'type' => 'string'
+          }
+        }
+      })
+    end
+  end
+
+  describe '#sub_types' do
+    it 'returns nested objects of a given entity' do
+      object_translator = described_class.new(StatusRepresenter.to_s)
+
+      expect(object_translator.sub_types).to eq([ImageRepresenter, StatusRepresenter])
+    end
+  end
+end

--- a/spec/swagger/integration_spec.rb
+++ b/spec/swagger/integration_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 require 'rake'
 load "#{File.dirname(__FILE__)}/../../lib/tasks/swagger.rake"
-require_relative 'grape/application_api'
+
+require_relative '../fixtures/grape/applications_api'
 
 describe 'Ruby::Swagger' do
   def no_stdout
@@ -402,8 +403,8 @@ describe 'Ruby::Swagger' do
                          )
       end
 
-      it 'should create a definition file StatusDetailed.yml' do
-        doc = open_yaml('./doc/swagger/definitions/StatusDetailed.yml')
+      it 'should create a definition file StatusDetailedEntity.yml' do
+        doc = open_yaml('./doc/swagger/definitions/StatusDetailedEntity.yml')
 
         expect(doc).to eq({ 'type' => 'object',
                             'properties' => {
@@ -415,8 +416,8 @@ describe 'Ruby::Swagger' do
                                                   'properties' => { 'phone' => { 'type' => 'string' },
                                                                     'address' => { 'type' => 'object', '$ref' => '#/definitions/ImageEntity' } } },
                               'digest' => { 'type' => 'string' },
-                              'responses' => { 'type' => 'object', '$ref' => '#/definitions/Status' },
-                              'last_reply' => { 'type' => 'object', '$ref' => '#/definitions/Status' },
+                              'responses' => { 'type' => 'object', '$ref' => '#/definitions/StatusEntity' },
+                              'last_reply' => { 'type' => 'object', '$ref' => '#/definitions/StatusEntity' },
                               'list' => { 'type' => 'array',
                                           'items' => { 'type' => 'object',
                                                        'properties' => {
@@ -431,8 +432,8 @@ describe 'Ruby::Swagger' do
                          )
       end
 
-      it 'should create a definition file Status.yml' do
-        doc = open_yaml('./doc/swagger/definitions/Status.yml')
+      it 'should create a definition file StatusEntity.yml' do
+        doc = open_yaml('./doc/swagger/definitions/StatusEntity.yml')
 
         expect(doc).to eq({ 'type' => 'object',
                             'properties' => {
@@ -444,8 +445,8 @@ describe 'Ruby::Swagger' do
                                                   'properties' => { 'phone' => { 'type' => 'string' },
                                                                     'address' => { 'type' => 'object', '$ref' => '#/definitions/ImageEntity' } } },
                               'digest' => { 'type' => 'string' },
-                              'responses' => { 'type' => 'object', '$ref' => '#/definitions/Status' },
-                              'last_reply' => { 'type' => 'object', '$ref' => '#/definitions/Status' },
+                              'responses' => { 'type' => 'object', '$ref' => '#/definitions/StatusEntity' },
+                              'last_reply' => { 'type' => 'object', '$ref' => '#/definitions/StatusEntity' },
                               'list' => { 'type' => 'array',
                                           'items' => { 'type' => 'object',
                                                        'properties' => {
@@ -458,6 +459,34 @@ describe 'Ruby::Swagger' do
                               'updated_at' => { 'type' => 'string' } } }
                          )
       end
+    end
+
+    it 'should create a definition file StatusRepresenter.yml' do
+      doc = open_yaml('./doc/swagger/definitions/StatusRepresenter.yml')
+
+      expect(doc).to eq({ 'type' => 'object',
+                          'properties' => {
+        'user_name' => { 'type' => 'string' },
+        'text' => { 'type' => 'string', 'description' => 'Status update text.' },
+        'ip' => { 'type' => 'string' }, 'user_type' => { 'type' => 'string' },
+        'user_id' => { 'type' => 'string' },
+        'contact_info' => { 'type' => 'object',
+                            'properties' => { 'phone' => { 'type' => 'string' },
+                                              'address' => { 'type' => 'object', '$ref' => '#/definitions/ImageRepresenter' } } },
+        'digest' => { 'type' => 'string' },
+        'responses' => { 'type' => 'object', '$ref' => '#/definitions/StatusRepresenter' },
+        'last_reply' => { 'type' => 'object', '$ref' => '#/definitions/StatusRepresenter' },
+        'list' => { 'type' => 'array',
+                    'items' => { 'type' => 'object',
+                                 'properties' => {
+                      'option_a' => { 'type' => 'object',
+                                      'properties' => {
+                        'option_b' => { 'type' => 'array',
+                                        'items' => { 'type' => 'string' }, 'description' => 'An option' } } },
+                      'option_c' => { 'type' => 'integer', 'description' => 'Last option' } } }, 'description' => 'List of elements' },
+        'created_at' => { 'type' => 'string' },
+        'updated_at' => { 'type' => 'string' } } }
+                       )
     end
   end
 end


### PR DESCRIPTION
It supports most of Roar/Representable DSL like: property, collection,
nested, extend, coercions. It still does not support hypermedia.

It's even possible to have a API with both Grape::Entity and Roar
working together (not sure why some one would require this, but we got
it for free)

Also:

- Clean up specs folder moving non-specs to fixtures 
  - Move test Grape application to fixtures folder
  - Keep file/classes naming conventions
  - Remove unnecessary requires
- Refactor `Swagger::Grape::Type` 
  - Add missing unity specs for `Grape::Unity` object translator
  - Add ability to receive custom swagger object translators
  - Avoid using instance variables directly
  - Ensure to only initialize object translator once by memoizing it
  - Remove unused `attr_reader`