### PR TITLE
Security is an array of SecurityRequirement

### DIFF
--- a/lib/ruby-swagger/data/document.rb
+++ b/lib/ruby-swagger/data/document.rb
@@ -139,11 +139,15 @@ module Swagger::Data
     def security=(new_security)
       return nil unless new_security
 
-      unless new_security.is_a?(Swagger::Data::SecurityRequirement)
-        new_security = Swagger::Data::SecurityRequirement.parse(new_security)
-      end
+      @security = []
 
-      @security = new_security
+      new_security.each do |sec_object|
+        unless sec_object.is_a?(Swagger::Data::SecurityRequirement)
+          sec_object = Swagger::Data::SecurityRequirement.parse(sec_object)
+        end
+
+        @security.push(sec_object)
+      end
     end
 
     def tags=(new_tags)


### PR DESCRIPTION
This is required to parse security requirements as per the 2.0 spec.

This iteration pattern exists elsewhere in the gem.

It doesn't look like spec/fixtures/json/resources/securityExample.json is used by the unit tests, but it does contain the spec security structure so I am not sure where to add tests.