### PR TITLE
Add/Pin gem versions to fix spec

### DIFF
--- a/ruby-swagger.gemspec
+++ b/ruby-swagger.gemspec
@@ -18,6 +18,6 @@ This is the engine used in other gems to translate API definitions (grape, rails
   s.add_development_dependency 'rack', '~> 1.0'
   s.add_development_dependency 'activesupport', '~> 4.2'
   s.add_development_dependency 'rake', '>= 0.9.2'
-  s.add_development_dependency 'roar'
+  s.add_development_dependency 'roar', '~> 1.0.4'
   s.add_development_dependency 'rspec'
 end

--- a/ruby-swagger.gemspec
+++ b/ruby-swagger.gemspec
@@ -15,6 +15,8 @@ This is the engine used in other gems to translate API definitions (grape, rails
   s.add_development_dependency 'grape'
   s.add_development_dependency 'grape-entity', '~> 0.5'
   s.add_development_dependency 'rack-test'
+  s.add_development_dependency 'rack', '~> 1.0'
+  s.add_development_dependency 'activesupport', '~> 4.2'
   s.add_development_dependency 'rake', '>= 0.9.2'
   s.add_development_dependency 'roar'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
Master is currently breaking (red) as of updated dependencies (AR, roar and rack). To fix this, this PR pins gems to according version before the break, resulting in a green spec run again.

Next steps are:

1. adapt code for roar 1.1.0
2. deprecate ruby 2.1 support, which will allow latest version of AR and rack