### PR TITLE
Add Grape Rack::Multipart::UploadedFile params handling

### DIFF
--- a/lib/ruby-swagger/grape/method.rb
+++ b/lib/ruby-swagger/grape/method.rb
@@ -135,6 +135,14 @@ module Swagger::Grape
       end
     end
 
+    def operation_multipart
+      if @operation.consumes.nil?
+        @operation.consumes = ['multipart/form-data']
+      elsif !@operation.consumes.include?('multipart/form-data')
+        @operation.consumes += ['multipart/form-data']
+      end
+    end
+
     # extract the tags
     def grape_tags
       (@route_settings.tags && !@route_settings.tags.empty?) ? @route_settings.tags : [@route_name.split('/')[1]]
@@ -152,10 +160,13 @@ module Swagger::Grape
       when 'delete'
         query_params
       when 'post'
+        file_params
         body_params
       when 'put'
+        file_params
         body_params
       when 'patch'
+        file_params
         body_params
       when 'head'
         raise ArgumentError.new("Don't know how to handle the http verb HEAD for #{@route_name}")
@@ -205,6 +216,20 @@ module Swagger::Grape
         swag_param.in = 'query'
 
         @params[parameter.first.to_s] = swag_param
+      end
+    end
+
+    def file_params
+      # extract all file params with type multipart/form-date
+
+      @route_settings.params.each do |parameter|
+        name, val = parameter
+        next if @params[name.to_s]
+        next unless val[:type].to_s == 'Rack::Multipart::UploadedFile'
+
+        operation_multipart
+        swag_param = Swagger::Data::Parameter.from_grape(parameter)
+        @params[name.to_s] = swag_param
       end
     end
 

--- a/lib/ruby-swagger/grape/type.rb
+++ b/lib/ruby-swagger/grape/type.rb
@@ -99,7 +99,7 @@ module Swagger::Grape
           'format' => 'float'
         },
         'rack::multipart::uploadedfile' => {
-          'type' => 'string' # 'Warning - I have no idea how to handle the type file. Right now I will consider this a string, but we should probably handle it...'
+          'type' => 'file'
         },
         'date' => {
           'type' => 'string',

--- a/spec/swagger/data/parameter_spec.rb
+++ b/spec/swagger/data/parameter_spec.rb
@@ -336,4 +336,26 @@ describe Swagger::Data::Parameter do
       end
     end
   end
+
+  describe '#from_grape' do
+    subject { Swagger::Data::Parameter.from_grape(parameter) }
+
+    context 'when type is Rack::Multipart::UploadedFile' do
+      let(:parameter) do
+        [
+          'param_name',
+          {
+            in: 'query',
+            description: 'the super string',
+            required: true,
+            type: 'Rack::Multipart::UploadedFile'
+          }
+        ]
+      end
+
+      it 'should translate to type file' do
+        expect(subject.type).to eq 'file'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Copy & rebase of #59, as the branch got deleted /cc @codingluke

A `Rack::Multipart::UploadFile` is handled like it would be a regular `body.string` param

```
requires :file, type: Rack::Multipart::UploadedFile, desc: 'File to upload'
"parameters": [
  {
    "name": "body",
    "in": "body",
    "description": "the content of the request",
    "schema": {
      "required": [
      "file"
    ],
      "type": "object",
      "properties": {
        "file": {
          "description": "File to upload",
          "required": true,
          "type": "string"
        }
      }
    }
  }
]
```

However, it would be nice to have it rendered like this, as swagger-ui in this case will render automatically a file picker.

```
"parameters": [
  {
    "name": "file",
    "in": "formData",
    "description": "File to upload",
    "required": true,
    "type": "file"
  }
]
```

To reach this, I just added a new Method `file_param` which is called before `body_param`. It extracts all the field params, creates the correct param schema and also adds the `['multipart/form-data']` to `operation.consumes`. I also modified `lib/ruby-swagger/grape/type.rb` so that it handels uploaded types correctly.