### PR TITLE
Support for custom status codes

### DIFF
--- a/lib/ruby-swagger/grape/grape_config.rb
+++ b/lib/ruby-swagger/grape/grape_config.rb
@@ -74,7 +74,18 @@ module Grape
           response_obj[:headers] = options[:headers] || options['headers']
           response_obj[:isArray] = options[:isArray] || options['isArray']
 
+          response_obj[:status_code] = status_code(options[:status_code] || options['status_code'])
+
           @api_options[:response] = response_obj
+        end
+
+        def status_code(code)
+          return '200' if code.nil?
+          return code.to_s if code.is_a?(Fixnum)
+          raise ArgumentError, 'Status code must be Fixnum, Symbol or nil.' unless code.is_a?(Symbol)
+          raise ArgumentError, "Status code :#{status} is invalid." unless Rack::Utils::SYMBOL_TO_STATUS_CODE.keys.include?(code)
+
+          Rack::Utils.status_code(code).to_s
         end
 
         def errors(errors_value)
@@ -127,6 +138,11 @@ module Grape
           @@response_root = new_value
         end
 
+        @@response_status_code = nil
+        def default_response_status_code(new_value)
+          @@response_status_code = new_value
+        end
+
         @@response_entity = nil
         def default_response_entity(new_value)
           @@response_entity = new_value
@@ -143,6 +159,7 @@ module Grape
               entity: @@response_entity,
               root: @@response_root,
               headers: @@response_headers,
+              status_code: @@response_status_code,
               isArray: false
             },
             errors: @@errors,

--- a/lib/ruby-swagger/grape/method.rb
+++ b/lib/ruby-swagger/grape/method.rb
@@ -17,7 +17,6 @@ module Swagger::Grape
       operation_params
       operation_responses
       operation_security
-
       self
     end
 
@@ -115,9 +114,11 @@ module Swagger::Grape
           end
 
         end
+
         # rubocop:enable IfInsideElse
 
-        @operation.responses.add_response('200', Swagger::Data::Response.parse(rainbow_response))
+        @operation.responses.add_response @route_settings.response[:status_code],
+                                          Swagger::Data::Response.parse(rainbow_response)
       end
 
       @operation.responses.add_response('default', Swagger::Data::Response.parse({ 'description' => 'Unexpected error' }))

--- a/spec/fixtures/grape/applications_api.rb
+++ b/spec/fixtures/grape/applications_api.rb
@@ -161,6 +161,29 @@ class ApplicationsAPI < Grape::API
       api_present(@applications)
     end
 
+    api_desc 'Delete roar' do
+      response StatusDetailedEntity, isArray: true, status_code: :accepted
+    end
+    delete '/:id/roar' do
+      @application = { id: '123456', name: 'An app', description: 'Great App' }
+      api_present(@applications)
+    end
+
+    api_desc 'Create a pet' do
+      response StatusDetailedEntity, isArray: true, status_code: :no_content
+    end
+    post('/pet') {}
+
+    api_desc 'Update a pet' do
+      response StatusDetailedEntity, isArray: true, status_code: 303, headers: {
+        'Location' => {
+          description: 'As per rfc2616',
+          type: 'string'
+        }
+      }
+    end
+    put('/pet') {}
+
     api_desc 'Deactivate an application.' do
       headers authentication_headers
       scopes %w(application:read application:write application:execute)

--- a/spec/swagger/integration_spec.rb
+++ b/spec/swagger/integration_spec.rb
@@ -343,6 +343,26 @@ describe 'Ruby::Swagger' do
 
         expect(doc['responses']['default']['description']).to eq 'Unexpected error'
       end
+
+      context '#response_code' do
+        subject { doc['responses'].keys }
+
+        describe 'roar#delete' do
+          let(:doc) { open_yaml('./doc/swagger/paths/applications/{id}/roar/delete.yml') }
+          it { is_expected.to include '202' }
+        end
+
+        describe 'pet#create' do
+          let(:doc) { open_yaml('./doc/swagger/paths/applications/pet/post.yml') }
+          it { is_expected.to include '204' }
+        end
+
+        describe 'pet#update' do
+          let(:doc) { open_yaml('./doc/swagger/paths/applications/pet/put.yml') }
+          it { is_expected.to include '303' }
+        end
+
+      end
     end
 
     describe 'definitions' do


### PR DESCRIPTION
Adds possibility to display custom defined response status codes. 

This PR is a 'backport' by @krule from our internal fork.


