### PR TITLE
ruby 2.1 no longer supported by mustermann

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
 rvm:
  - "2.2.3"
- - "2.1.2"
 script: bundle exec rspec spec


### PR DESCRIPTION
Removing ruby 2.1.x from Travis build as mustermann no longer supports Ruby 2.1